### PR TITLE
Release 0.0.19

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 CHANGELOG
 =========
 
+0.0.19
+======
+
+* Support for ``#/components/responses``
+* Support for ``#/components/headers``
+* Support for ``#/components/parameters``
+* ``ObjectWithAdditionalProperties`` supports boolean value
+* Support for header schemas referenced through ``$ref``
+
 0.0.6
 =====
 

--- a/openapi_type/__init__.py
+++ b/openapi_type/__init__.py
@@ -121,9 +121,71 @@ SchemaType = Union[ StringValue  # type: ignore
                   ]
 
 
+class ParamLocation(Enum):
+    QUERY = 'query'
+    HEADER = 'header'
+    PATH = 'path'
+    COOKIE = 'cookie'
+
+
+class ParamStyle(Enum):
+    """
+    * https://swagger.io/specification/#style-values
+    * https://swagger.io/specification/#style-examples
+    """
+    FORM = 'form'
+    SIMPLE = 'simple'
+    MATRIX = 'matrix'
+    LABEL = 'label'
+    SPACE_DELIMITED = 'spaceDelimited'
+    PIPE_DELIMITED = 'pipeDelimited'
+    DEEP_OBJECT = 'deepObject'
+
+
+class OperationParameter(NamedTuple):
+    name: str
+    in_: ParamLocation
+    schema: SchemaType
+    required: bool = False
+    description: str = ''
+    style: Optional[ParamStyle] = None
+    explode: Optional[bool] = None
+
+
+class Header(NamedTuple):
+    """ response header
+    """
+    schema: SchemaType
+    description: str = ''
+
+
+HTTPCode = NewType('HTTPCode', str)
+HeaderName = NewType('HeaderName', str)
+
+
+class MediaType(NamedTuple):
+    """ https://swagger.io/specification/#media-type-object
+    """
+    schema: Optional[SchemaType] = None
+    example: Union[None, str, PMap[str, Any]] = None
+    examples: Mapping[str, Any] = pmap()
+    encoding: Mapping[str, Any] = pmap()
+
+
+class Response(NamedTuple):
+    """ Response of an endpoint
+    """
+    content: PMap[ContentTypeTag, MediaType] = pmap()
+    headers: PMap[HeaderName, Union[Header, Reference]] = pmap()
+    description: str = ''
+
+
 class Components(NamedTuple):
     schemas: Mapping[str, SchemaType]
     links: Mapping[str, SchemaType] = pmap()
+    parameters: Mapping[str, OperationParameter] = pmap()
+    responses: Mapping[str, Response] = pmap()
+    headers: Mapping[str, Header] = pmap()
     request_bodies: Mapping[str, Any] = pmap()
     security_schemes: Mapping[str, Any] = pmap()
 
@@ -166,65 +228,6 @@ class SpecFormat(Enum):
     V3_0_0 = '3.0.0'
     V3_0_1 = '3.0.1'
     V3_0_2 = '3.0.2'
-
-
-class ParamLocation(Enum):
-    QUERY = 'query'
-    HEADER = 'header'
-    PATH = 'path'
-    COOKIE = 'cookie'
-
-
-class ParamStyle(Enum):
-    """
-    * https://swagger.io/specification/#style-values
-    * https://swagger.io/specification/#style-examples
-    """
-    FORM = 'form'
-    SIMPLE = 'simple'
-    MATRIX = 'matrix'
-    LABEL = 'label'
-    SPACE_DELIMITED = 'spaceDelimited'
-    PIPE_DELIMITED = 'pipeDelimited'
-    DEEP_OBJECT = 'deepObject'
-
-
-class OperationParameter(NamedTuple):
-    name: str
-    in_: ParamLocation
-    schema: SchemaType
-    required: bool = False
-    description: str = ''
-    style: Optional[ParamStyle] = None
-    explode: Optional[bool] = None
-
-
-HTTPCode = NewType('HTTPCode', str)
-HeaderName = NewType('HeaderName', str)
-
-
-class Header(NamedTuple):
-    """ response header
-    """
-    schema: SchemaType
-    description: str = ''
-
-
-class MediaType(NamedTuple):
-    """ https://swagger.io/specification/#media-type-object
-    """
-    schema: Optional[SchemaType] = None
-    example: Union[None, str, PMap[str, Any]] = None
-    examples: Mapping[str, Any] = pmap()
-    encoding: Mapping[str, Any] = pmap()
-
-
-class Response(NamedTuple):
-    """ Response of an endpoint
-    """
-    content: PMap[ContentTypeTag, MediaType] = pmap()
-    headers: PMap[HeaderName, Union[Header, Reference]] = pmap()
-    description: str = ''
 
 
 class ExternalDoc(NamedTuple):

--- a/openapi_type/__init__.py
+++ b/openapi_type/__init__.py
@@ -52,8 +52,11 @@ RecursiveAttrs = Mapping[str, 'SchemaType']  # type: ignore
 
 
 class ObjectWithAdditionalProperties(NamedTuple):
+    """ Represents a free-form object
+    https://swagger.io/docs/specification/data-models/dictionaries/#free-form
+    """
     type: Literal['object']
-    additional_properties: Optional['SchemaType'] = None  # type: ignore
+    additional_properties: Union[None, bool, 'SchemaType'] = None  # type: ignore
 
 
 class ArrayValue(NamedTuple):
@@ -220,7 +223,7 @@ class Response(NamedTuple):
     """ Response of an endpoint
     """
     content: PMap[ContentTypeTag, MediaType] = pmap()
-    headers: PMap[HeaderName, Header] = pmap()
+    headers: PMap[HeaderName, Union[Header, Reference]] = pmap()
     description: str = ''
 
 

--- a/openapi_type/custom_types.py
+++ b/openapi_type/custom_types.py
@@ -76,8 +76,11 @@ class ContentTypeTagSchema(typeit.schema.primitives.Str):
 
 
 class RefTo(Enum):
-    SCHEMAS = '#/components/schemas/'
-    LINKS = '#/components/links/'
+    SCHEMAS   = '#/components/schemas/'
+    LINKS     = '#/components/links/'
+    PARAMS    = '#/components/parameters/'
+    RESPONSES = '#/components/responses/'
+    HEADERS   = '#/components/headers/'
 
 
 class Ref(NamedTuple):
@@ -90,6 +93,9 @@ class RefSchema(typeit.schema.primitives.Str):
     REF_LOCATIONS: Mapping[str, RefTo] = {
         'schemas': RefTo.SCHEMAS,
         'links': RefTo.LINKS,
+        'parameters': RefTo.PARAMS,
+        'responses': RefTo.RESPONSES,
+        'headers': RefTo.HEADERS,
     }
 
     def deserialize(self, node, cstruct: str) -> Ref:
@@ -113,7 +119,7 @@ class RefSchema(typeit.schema.primitives.Str):
         try:
             ref_location = self.REF_LOCATIONS[location]
         except KeyError:
-            raise Invalid(node, "Unrecognised reference location", ref_str)
+            raise Invalid(node, f"Unrecognised reference location '{location}'", ref_str)
 
         return Ref(ref_location, ref_name)
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with (here / 'README.rst').open() as f:
 # ----------------------------
 
 setup(name='openapi-type',
-      version='0.0.18',
+      version='0.0.19',
       description='OpenAPI Type',
       long_description=README,
       classifiers=[


### PR DESCRIPTION
* Support for ``#/components/responses``
* Support for ``#/components/headers``
* Support for ``#/components/parameters``
* ``ObjectWithAdditionalProperties`` supports boolean value
* Support for header schemas referenced through ``$ref``